### PR TITLE
Hotfix for Symfony 2.6 Compatibility

### DIFF
--- a/Form/Type/CKFinderType.php
+++ b/Form/Type/CKFinderType.php
@@ -27,28 +27,28 @@ class CKFinderType extends CKEditorType
     {
     	parent::setDefaultOptions($resolver);
 
-    	$resolver->replaceDefaults(array(
+    	$resolver->setDefaults(array(
     		'config' => array(
 	            'filebrowserBrowseUrl' => $this->router->generate('ckfinder_index'),
 	            'filebrowserImageBrowseUrl' => $this->router->generate('ckfinder_index', array('type' => 'images')),
 	            'filebrowserFlashBrowseUrl' => $this->router->generate('ckfinder_index', array('type' => 'flash')),
 	            'filebrowserUploadUrl' => $this->router->generate('ckfinder_init', array(
-	                'command' => 'QuickUpload', 
-	                'type' => 'files', 
+	                'command' => 'QuickUpload',
+	                'type' => 'files',
 	                'service' => 'php'
 	            )),
 	            'filebrowserImageUploadUrl' => $this->router->generate('ckfinder_init', array(
-	                'command' => 'QuickUpload', 
-	                'type' => 'images', 
+	                'command' => 'QuickUpload',
+	                'type' => 'images',
 	                'service' => 'php'
 	            )),
 	            'filebrowserFlashUploadUrl' => $this->router->generate('ckfinder_init', array(
-	        		'command' => 'QuickUpload', 
-	        		'type' => 'flash', 
+	        		'command' => 'QuickUpload',
+	        		'type' => 'flash',
 	        		'service' => 'php'
 	        	))
-        	))
-		);
+        	)
+        ));
     }
 
     public function getName()


### PR DESCRIPTION
In 2.6, OptionsResolverInterface has changed, `replaceDefaults()` acts differently now (replaces everything) where `setDefaults()` merges the differences 

This is a temporary fix, as `OptionsResolverInterface` has been marked as Deprecated and planned to be removed for Symfony 3.0

It is recommended instead to simply use `OptionsResolver`, but currently this doesn't not coincide with a proper override and breaks the library entirely.